### PR TITLE
Feat: standardized tag-push workflow and fix dependabot config

### DIFF
--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -1,0 +1,48 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# Runs on tag push, promotes draft release
+name: 'Release on Tag Push 🚀'
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    tags:
+      # Triggered only by semantic tags push
+      - '**'
+
+permissions: {}
+
+jobs:
+  promote-release:
+    name: 'Promote Draft Release'
+    # yamllint disable-line rule:line-length
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: 'ubuntu-24.04'
+    permissions:
+      contents: write
+    timeout-minutes: 3
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863  # v2.12.1
+        with:
+          egress-policy: audit
+
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: 'Verify Pushed Tag'
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/tag-push-verify-action@f9c6e753870c6405883be2ba18af05d075aaffe8  # v0.1.0
+        with:
+          versioning: 'semver'
+
+      - name: 'Promote draft release'
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/draft-release-promote-action@d7e7df12e32fa26b28dbc2f18a12766482785399  # v0.1.2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{ github.ref_name }}"
+          latest: true


### PR DESCRIPTION
This PR adds the standardized `tag-push.yaml` workflow and fixes the dependabot configuration to ensure consistency across all LF RelEng Actions repositories.

## Changes Made

### 1. Added `.github/workflows/tag-push.yaml`
- Standardized workflow for tag validation and pushing
- Ensures consistent tag handling across all action repositories
- Includes proper permissions and security configurations

### 2. Fixed `.github/dependabot.yml`
- Added proper SPDX license header
- Configured commit message prefix as "Chore: " for consistency
- Standardized YAML formatting and structure
- Set up proper update schedule for GitHub Actions dependencies

## Benefits

- **Consistency**: All repositories now follow the same workflow patterns
- **Security**: Proper permissions and validation in place
- **Maintainability**: Standardized dependabot configuration reduces maintenance overhead
- **Compliance**: Proper SPDX headers ensure license compliance

## Testing

- Pre-commit hooks pass successfully
- Workflow syntax validated
- YAML files properly formatted
- No breaking changes to existing functionality

This change is part of a broader effort to standardize and improve the LF RelEng Actions ecosystem.