### PR TITLE
CI(dependabot): Add 7-day update cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
     open-pull-requests-limit: 15
     commit-message:
       prefix: "Chore"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds a 7-day `cooldown` to every enabled Dependabot ecosystem in
`.github/dependabot.yml`, satisfying the Zizmor workflow audit which
flags ecosystems that open version-bump PRs without a cooldown window.

This makes dependency bump PRs wait before opening, avoiding churn on
releases that are retracted or superseded shortly after they ship.