### PR TITLE
Chore: bump python-project-name-action to v0.1.7

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -77,7 +77,7 @@ runs:
     - name: 'Extract project/repository naming'
       id: naming
       # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/python-project-name-action@9f2cc7d37847d5f5497ba87d14e574b2f0a07462 # v0.1.6
+      uses: lfreleng-actions/python-project-name-action@4190dfce1bd534d7976dd031d455da392ff55321 # v0.1.7
       with:
         path_prefix: "${{ inputs.path_prefix }}"
 


### PR DESCRIPTION
## Summary

Bump `lfreleng-actions/python-project-name-action` from `v0.1.6`
(`9f2cc7d3`) to `v0.1.7` (commit `4190dfce`) to pick up the latest
release.

## Rationale

`python-project-name-action@v0.1.7` was recently tagged, and this
repository consumes it. The action call remains pinned to a commit
SHA per project convention.
