### PR TITLE
CI(security): Resolve zizmor auditor findings

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,8 +20,7 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Required to create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:

--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -13,6 +13,11 @@ on:
 
 permissions: {}
 
+# Serialize release promotions: only one tag-push run proceeds at a time
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   validate_tag:
     name: 'Validate Tag'
@@ -53,7 +58,7 @@ jobs:
     needs: validate_tag
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: write
+      contents: write  # Promote (publish) the draft release
     timeout-minutes: 5
     steps:
       # Harden the runner used by this workflow

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -26,6 +26,10 @@ jobs:
   tests:
     name: 'Test local GitHub Action'
     runs-on: ubuntu-24.04
+    # Run this job in a dedicated environment so its execution and any
+    # environment-scoped secrets can be gated by environment protection
+    # rules (satisfies zizmor's secrets-outside-env).
+    environment: 'development'
     permissions:
       contents: read
     timeout-minutes: 15
@@ -38,6 +42,8 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Perform setup prior to running test(s)
       - name: 'Checkout sample project repository'
@@ -45,6 +51,7 @@ jobs:
         with:
           repository: "lfreleng-actions/test-python-project"
           path: 'test-python-project'
+          persist-credentials: false
 
       - name: 'Build Python project'
         # yamllint disable-line rule:line-length


### PR DESCRIPTION
## Summary

Drives the [zizmor](https://docs.zizmor.sh) static analysis to **zero
findings at the `auditor` persona** — the level the central CI security
scan uses (previously this branch only cleared `pedantic`, leaving the
`auditor`-only medium findings visible on the dashboard).

## Findings addressed

| Audit | Sev | Count | Fix |
| ----- | --- | ----- | --- |
| `secrets-outside-env` | medium | 2 | Bind the test job to the shared `development` environment so the publish / 1Password secrets are scoped to a gated environment rather than the repository scope. |
| `artipacked` | low | 2 | `persist-credentials: false` on every `actions/checkout`. |
| `concurrency-limits` | low | 1 | Workflow-level `concurrency` group on the tag-push release workflow. |
| `undocumented-permissions` | low | 2 | Trailing explanatory comments on non-baseline permission grants. |

## Validation

- `zizmor --persona=auditor .` → **No findings to report**.
- `pre-commit` (yamllint, actionlint, reuse, workflow validators) passes.