### PR TITLE
Fix: Bump publish backend to v1.11.11

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -356,7 +356,7 @@ runs:
       # Also, be cautious pinning v1.12.x to a SHA commit value:
       # https://github.com/pypa/gh-action-pypi-publish/discussions/287
       # yamllint disable-line rule:line-length
-      uses: modeseven-lfreleng-actions/gh-action-pypi-publish@2bd65a5f4532bf320106f42bfd918026d0946fb3  # v1.11.8
+      uses: modeseven-lfreleng-actions/gh-action-pypi-publish@38ce3360480397d746f63159bce98ac5e8e0218d  # v1.11.11
       # yamllint disable-line rule:line-length
       if: steps.conditions.outputs.publish_method == 'Trusted Publishing' && inputs.publish_disable == 'false'
       with:
@@ -425,7 +425,7 @@ runs:
       # Also, be cautious pinning v1.12.x to a SHA commit value:
       # https://github.com/pypa/gh-action-pypi-publish/discussions/287
       # yamllint disable-line rule:line-length
-      uses: modeseven-lfreleng-actions/gh-action-pypi-publish@2bd65a5f4532bf320106f42bfd918026d0946fb3  # v1.11.8
+      uses: modeseven-lfreleng-actions/gh-action-pypi-publish@38ce3360480397d746f63159bce98ac5e8e0218d  # v1.11.11
       # yamllint disable-line rule:line-length
       if: steps.conditions.outputs.publish_method == '1Password Vault' && inputs.publish_disable == 'false'
       with:
@@ -446,7 +446,7 @@ runs:
       # Also, be cautious pinning v1.12.x to a SHA commit value:
       # https://github.com/pypa/gh-action-pypi-publish/discussions/287
       # yamllint disable-line rule:line-length
-      uses: modeseven-lfreleng-actions/gh-action-pypi-publish@2bd65a5f4532bf320106f42bfd918026d0946fb3  # v1.11.8
+      uses: modeseven-lfreleng-actions/gh-action-pypi-publish@38ce3360480397d746f63159bce98ac5e8e0218d  # v1.11.11
       if:
         # yamllint disable-line rule:line-length
         steps.conditions.outputs.publish_method == 'GitHub Secret' && inputs.publish_disable == 'false'


### PR DESCRIPTION
Bumps the pinned publishing backend from **v1.11.8 → v1.11.11** across all three call sites.

## Why

The pinned backend rejected any distribution declaring `Metadata-Version: 2.5`, which Hatchling 1.30 and newer emit by default:

```
ERROR    InvalidDistribution: Invalid distribution metadata: '2.5' is not a
         valid metadata version
```

This broke tagged releases — see [lfreleng-actions/lftools-uv run 31725353675](https://github.com/lfreleng-actions/lftools-uv/actions/runs/31725353675/job/94533884530).

The failure came from the twine bundled in the backend container, **not** from PyPI. twine replaces `packaging`'s list of valid metadata versions with its own hard-coded copy, which stopped at `2.4`, so it could not be fixed by bumping `packaging` or by anything downstream of the backend. The new pin carries twine 7.0, whose copy includes `2.5`.

PyPI itself already accepts the version, since confirmed in production: `lftools-uv` 0.5.3 published successfully from a metadata 2.5 artefact.

## What the new pin brings

- **twine 7.0** — accepts metadata 2.5.
- **All 30 open dependency security advisories cleared**, including two majors on the attestation signing path (`cryptography` 46→50, `pyopenssl` 25→26) plus `urllib3` 2.7.0, `pyjwt` 2.13.0, `pyasn1` 0.6.4, `tuf` 7.0.0.
- **A metadata-version canary in the backend's CI**, which builds its test stub with an unpinned Hatchling so the newest core metadata version is always exercised against the pinned twine. This class of failure now surfaces as a red CI job rather than a broken release.

## Scope

All three call sites move together, so **Trusted Publishing**, the **1Password credential** path and the **GitHub secret** fallback stay on a single backend version — worth keeping in lockstep, since a split would be easy to miss and hard to debug.

The pin stays within the **v1.11.x** series, so the existing cautionary comments about v1.12.x container-creation changes remain accurate and are untouched.

## Pin correctness

The tag is annotated, so the pinned value is the **commit** it points at, not the tag object:

```console
$ git cat-file -t v1.11.11
tag

$ git rev-parse v1.11.11
9ceef548118838612ce6284fa701837f1993ca36   # tag object — NOT this

$ git rev-parse 'v1.11.11^{commit}'
38ce3360480397d746f63159bce98ac5e8e0218d   # commit — pinned
```

## Note on v1.11.10 → v1.11.11

This PR originally pinned v1.11.10. Retargeted to v1.11.11 so the pin lands on the newest release rather than inviting an immediate Dependabot bump on top of the merge.

The two releases are **functionally identical for consumers** — everything that differs is under `.github/` (CI workflows and Dependabot config):

```console
$ git diff --name-only v1.11.10 v1.11.11 | grep -v '^\.github/'
# (no output)
```

`action.yml`, `Dockerfile`, `twine-upload.sh` and `requirements/` are unchanged, so the container built is the same. The branch name still says `v1-11-10`; renaming it would close this PR, so I have left it.

## Verification

- **Zizmor** (`--persona auditor`): **no findings**, on `action.yaml` and across the whole repository.
- Pre-commit hooks pass, including `yamllint` and `Validate GitHub Actions`.
- The backend image was built and verified against the exact artefacts that failed in the linked run: `twine check` PASSED for both wheel and sdist, and the attestation path (`Distribution.from_file`, TUF refresh, `SigningContext`) constructs successfully under the new majors.

## Limitation

The OIDC exchange and the actual signing call need an ambient credential and could not be exercised locally, so the first real trusted-publishing run after this merge is the true end-to-end test of the attestation path. Given the two majors on that path, it is worth watching that job rather than assuming it.
